### PR TITLE
Melhorias e sugestões nas convenções de nomes e organização de pastas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,19 @@ O fluxo de dados funciona da seguinte forma: **CRUD → INTERFACE → CONTROLLER
 
 ## 📁 Estrutura de Pastas
 
-PASTAS      | DESCRIÇÃO
------------ | -----------
-/assets     | Arquivos de view (JS/CSS/HTML) em apps web e documentos estáticos como imagens, vídeos
-/interface  | Interfaces de CRUD (1 por funcionalidade)
-/controller | Regras de negócio e orquestração de dados (consome interface)
-/receiver   | Pasta para recebimento de hooks de outros sistemas ou API's
-/api        | Endpoints públicos ou internos da aplicação (REST, JSON, etc).
-/screens    | Para views em apps mobile ou desktop
-/utils      | Classes utilitárias (tratamento de erros, queries, constantes)
-/ (root)    | Apenas a view principal (mobile e desktop), ou um conjunto de views no caso da web
+PASTAS          | DESCRIÇÃO
+----------------|------------
+/src            | Pasta contentendo serviços e entidades communs ao projeto, podem ser usados nos controllers, receiver, api, screens e etc.
+/src/services   | Pasta destinada a serviços como consumo de API de terceiros, serviços de email, serviços de pagamento como abstração de gatesways e etc.
+/src/entities   | Interfaces e modelos de CRUD (1 por funcionalidade)
+/src/utils      | Classes utilitárias (tratamento de erros, queries, constantes)
+/controllers    | Regras de negócio e orquestração de dados (consome interface)
+/receiver       | Pasta para recebimento de hooks de outros sistemas ou API's
+/assets         | Arquivos de view (JS/CSS/HTML) em apps web e documentos estáticos como imagens, vídeos
+/api            | Endpoints públicos ou internos da aplicação (REST, JSON, etc).
+/screens        | Para views em apps mobile ou desktop
+/utils          | Classes utilitárias (tratamento de erros, queries, constantes)
+/(root)         | Apenas a view principal (mobile e desktop), ou um conjunto de views no caso da web
 
 <br>
 
@@ -144,36 +147,42 @@ Imagine que você tem um sistema web que processa pagamentos, então a estrutura
 
 ```shell
 .
+├── src
+│   ├── entities
+│   │   ├── Bd.php
+│   │   ├── Usuarios.php
+│   │   ├── Pagamentos.php
+│   │   └── Csv.php
+│   ├── utils
+│   │   ├── erros.php
+│   │   ├── funcoes.php
+│   │   └── queries.php
+│   └── services
+│       └── gateways
+│           ├── PargameGateway.php
+│           ├── PagSeguroGateway.php
+│           └── MercadoPagoGateway.php
 ├── assets
-│   └── _css
-│   └── _imagens
-│   └── _javascript
-├── classes
-│   └── interface-bd.php
-│   └── interface-usuarios.php
-│   └── interface-pagamentos.php
-│   └── interface-csv.php
+│   ├── css
+│   ├── imagens
+│   └── javascript
 ├── controller
-│   └── controller-usuarios.php
-│   └── controller-pagamentos.php
-│   └── controller-csv.php
-├── utils
-│   └── erros.php
-│   └── funcoes.php
-│   └── queries.php
+│   ├── ControllerUsuarios.php
+│   ├── ControllerPagamentos.php
+│   └── ControllerCsv.php
 ├── api
 │   └── pagamentos
-│       └── rotas-pagamentos.php
+│       ├── RotasPagamentos.php
 │       └── api-pagamentos.php
 ├── login.html
 ├── dashboard-pagamentos.html
 
 ```
 
-### Interface interface-pagamentos.php
+### Entity Pagamentos.php
 
 ```php
-require_once 'interface-bd.php';
+require_once 'Bd.php';
 require_once '../utils/queries.php';
 
 /**
@@ -259,7 +268,7 @@ class Pagamentos implements PagamentosInterface {
 
 ---
 
-### controller-pagamentos.php
+### ControllerPagamentos.php
 
 ```php
 
@@ -276,7 +285,7 @@ require_once '../utils/funcoes.php';
  * Arquivo que define os métodos para a lógica de pagamentos.
  */
 
-class PagamentosController
+class ControllerPagamentos
 {
 
     private Pagamentos $pagamentos;
@@ -374,7 +383,7 @@ class PagamentosController
 
 ---
 
-### rotas-pagamentos.php
+### RotasPagamentos.php
 
 ```php
 <?php
@@ -390,7 +399,7 @@ class PagamentosController
      * Arquivo com os métodos de processamento HTTP.
      */
 
-    class PagamentosRotas 
+    class RotasPagamentos 
     {
         private PagamentosController $pagamentosController;
     
@@ -455,7 +464,7 @@ class PagamentosController
 
 ```php
 <?php
-    require_once 'rotas-pagamentos.php';
+    require_once 'RotasPagamentos.php';
 
     /**
      * @author Pedro Stein Serer

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Aqui, os dados são os protagonistas. Todo o fluxo da aplicação gira em torno 
 
 A lógica é simples: praticamente todo processo empresarial ou problema real pode ser modelado como um CRUD. A computação resolve problemas porque abstrai esses processos. Então, se tudo é um CRUD, **a solução pode (e deve) ser simples**.
 
-O fluxo de dados funciona da seguinte forma: **CRUD → ENTIDADE → CONTROLLERS → VIEWS/API**.
+O fluxo de dados funciona da seguinte forma: **CRUD → CONTRATO → CONTROLLERS → VIEWS/API**.
 
 <ul>
   <li><p><b>CRUD: </b> Cada funcionalidade nasce como um CRUD básico. Pode crescer, mas sem virar um monstro. Nada de violar responsabilidade do arquivo.</p></li>
   <li><p><b>CLASSES: </b> São as classes que lidam diretamente com o BD. Isoladas, focadas. Um CRUD por classe. Se precisar, você estende.</p></li>
-  <li><p><b>CONTROLLERS: </b> Capturam os dados das entidades, aplicam regras de negócio e preparam a saída.</p></li>
+  <li><p><b>CONTROLLERS: </b> Capturam os dados das contratos, aplicam regras de negócio e preparam a saída.</p></li>
   <li><p><b>VIEWS/API: </b> Aqui termina o ciclo. É só a apresentação: seja para humanos (HTML) ou máquinas (JSON, XML, etc). Nada de lógica aqui.</p></li>
 </ul>
 
@@ -39,11 +39,10 @@ O fluxo de dados funciona da seguinte forma: **CRUD → ENTIDADE → CONTROLLERS
 
 PASTAS          | DESCRIÇÃO
 ----------------|------------
-/src            | Pasta contentendo serviços e entidades communs ao projeto, podem ser usados nos controllers, receiver, api, screens e etc.
-/src/services   | Pasta destinada a serviços como consumo de API de terceiros, serviços de email, serviços de pagamento como abstração de gatesways e etc.
-/src/entities   | Entidades de CRUD (1 por funcionalidade)
-/src/utils      | Classes utilitárias (tratamento de erros, queries, constantes)
-/controllers    | Regras de negócio e orquestração de dados (consome entidade)
+/services       | Pasta destinada a serviços como consumo de API de terceiros, serviços de email, serviços de pagamento como abstração de gatesways e etc.
+/contracts      | Contratos de CRUD (1 por funcionalidade)
+/utils          | Classes utilitárias (tratamento de erros, queries, constantes)
+/controllers    | Regras de negócio e orquestração de dados (consome contrato)
 /receiver       | Pasta para recebimento de hooks de outros sistemas ou API's
 /assets         | Arquivos de view (JS/CSS/HTML) em apps web e documentos estáticos como imagens, vídeos
 /api            | Endpoints públicos ou internos da aplicação (REST, JSON, etc).
@@ -59,24 +58,24 @@ PASTAS          | DESCRIÇÃO
 
 - As pastas abaixo são **obrigatórias** e formam o núcleo do backend na arquitetura **Zero**:
 
-  - ### 🔹 Entities (`/src/entities`)
-    - Cada funcionalidade do sistema (ex: Usuário, Produto, Pedido) tem **sua entidade CRUD** separada.
-    - Essas entidades ou modelos definem os métodos esperados para qualquer tipo de operação com o banco.
+  - ### 🔹 Contracts (`/contracts`)
+    - Cada funcionalidade do sistema (ex: Usuário, Produto, Pedido) tem **sua contrato CRUD** separada.
+    - Esses contratos definem os métodos esperados para qualquer tipo de operação com o banco.
     - São independentes da linguagem. Em TypeScript, Dart, Java... seguem o mesmo princípio.
 
-  - ### 🔹 Utils (`/src/utils`)
+  - ### 🔹 Utils (`/utils`)
     - Contém utilitários centrais que apoiam toda a camada de backend:
       - `ErrorHandler` → Classe abstrata que padroniza erros e mensagens de exceção.
       - `QueryProvider` → Armazena queries SQL como **constantes** ou **variáveis dinâmicas**, dependendo da linguagem.
       - `LogicHelper` → Funções para regra de negócio, máscaras, segurança, etc. (máx. ~10 funções).
   
-  - ### 🔹 Services (`/src/services`)
+  - ### 🔹 Services (`/services`)
     - Contém serviços que consomem APIs de terceiros ou serviços externos:
       - Exemplo: `PaymentGateway` para integração com gateways de pagamento.
       - Cada serviço deve ser modular e reutilizável, podendo ser chamado por controllers ou outras partes do sistema.
   
   - ### 🔹 Controllers (`/controller`)
-    - Cada entidade tem um controller correspondente.
+    - Cada contrato tem um controller correspondente.
     - Ele **implementa** as chamadas para o banco via classe e alimenta **views ou APIs**.
     - Exemplo: `UserController` chama `UserCRUD` e envia dados para o front ou resposta de API.
 
@@ -119,14 +118,14 @@ PASTAS          | DESCRIÇÃO
 
 ## 🚀 Escalabilidade
 
-Essa arquitetura suporta sistemas mais complexos, que contenham pedidos, estoque, comissão, notificações, suporte e etc, pois ela trata tudo como uma entidade, por exemplo:
+Essa arquitetura suporta sistemas mais complexos, que contenham pedidos, estoque, comissão, notificações, suporte e etc, pois ela trata tudo como um contrato, por exemplo:
 
 - Estoque é um CRUD;
 - Comissão é um CRUD;
 - Notificações é um CRUD;
 - Suporte é também um CRUD.
 
-Basicamente qualquer coisa é um CRUD, sendo que cada funcionalidade vai ter uma entidade (CRUD), um controller com os métodos que asseguram o funcionamento correto do sistema, uma classe de rotas e seu próprio endpoint. Se for necessário atomicidade, então cabe o desenvolvedor escolher qual arquivo será responsável por controlar a atomicidade, por exemplo, imagine o seguinte fluxo: **CRIAR PEDIDOS → DISPARAR FATURAMENTO → ATUALIZAR O ESTOQUE → GERAR COMISSÃO PARA O VENDEDOR → ENVIAR UM EMAIL**.
+Basicamente qualquer coisa é um CRUD, sendo que cada funcionalidade vai ter um contrato (CRUD), um controller com os métodos que asseguram o funcionamento correto do sistema, uma classe de rotas e seu próprio endpoint. Se for necessário atomicidade, então cabe o desenvolvedor escolher qual arquivo será responsável por controlar a atomicidade, por exemplo, imagine o seguinte fluxo: **CRIAR PEDIDOS → DISPARAR FATURAMENTO → ATUALIZAR O ESTOQUE → GERAR COMISSÃO PARA O VENDEDOR → ENVIAR UM EMAIL**.
 
 Se for necessário dar um rollback, é possível fazer de várias maneiras simples, sendo uma, que o sistema só valida tudo no final de todas as etapas, num arquivo que envia o email. Então o sistema cria o pedido e o insere no banco, que não teria problema se o pedido não fosse concluído já basta ter uma flag nesse pedido, sendo bom até para análises de marketing. Se ele conseguir atualizar o estoque, ele dispara o faturamento e se tudo ocorrer bem com o diparo, ele gera a comissão e envia o email.
 
@@ -152,21 +151,21 @@ Imagine que você tem um sistema web que processa pagamentos, então a estrutura
 
 ```shell
 .
-├── src
-│   ├── entities
-│   │   ├── Bd.php
-│   │   ├── Usuarios.php
-│   │   ├── Pagamentos.php
-│   │   └── Csv.php
-│   ├── utils
-│   │   ├── erros.php
-│   │   ├── funcoes.php
-│   │   └── queries.php
-│   └── services
-│       └── gateways
-│           ├── PargameGateway.php
-│           ├── PagSeguroGateway.php
-│           └── MercadoPagoGateway.php
+
+├── contracts
+│   ├── Bd.php
+│   ├── Usuarios.php
+│   ├── Pagamentos.php
+│   └── Csv.php
+├── utils
+│   ├── erros.php
+│   ├── funcoes.php
+│   └── queries.php
+└── services
+    └── gateways
+        ├── PargameGateway.php
+        ├── PagSeguroGateway.php
+        └── MercadoPagoGateway.php
 ├── assets
 │   ├── css
 │   ├── imagens

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Aqui, os dados são os protagonistas. Todo o fluxo da aplicação gira em torno 
 
 A lógica é simples: praticamente todo processo empresarial ou problema real pode ser modelado como um CRUD. A computação resolve problemas porque abstrai esses processos. Então, se tudo é um CRUD, **a solução pode (e deve) ser simples**.
 
-O fluxo de dados funciona da seguinte forma: **CRUD → CONTRATO → WORKERS → VIEWS/API**.
+O fluxo de dados funciona da seguinte forma: **CRUD → CONTRACTS → WORKERS → VIEWS/API**.
 
 <ul>
   <li><p><b>CRUD: </b> Cada funcionalidade nasce como um CRUD básico. Pode crescer, mas sem virar um monstro. Nada de violar responsabilidade do arquivo.</p></li>
-  <li><p><b>CLASSES: </b> São as classes que lidam diretamente com o BD. Isoladas, focadas. Um CRUD por classe. Se precisar, você estende.</p></li>
+  <li><p><b>CONTRACTS: </b> São as classes que lidam diretamente com o BD. Isoladas, focadas. Um CRUD por contrato. Se precisar, você estende.</p></li>
   <li><p><b>WORKERS: </b> Capturam os dados dos contratos, aplicam regras de negócio e preparam a saída.</p></li>
   <li><p><b>VIEWS/API: </b> Aqui termina o ciclo. É só a apresentação: seja para humanos (HTML) ou máquinas (JSON, XML, etc). Nada de lógica aqui.</p></li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Aqui, os dados são os protagonistas. Todo o fluxo da aplicação gira em torno 
 
 A lógica é simples: praticamente todo processo empresarial ou problema real pode ser modelado como um CRUD. A computação resolve problemas porque abstrai esses processos. Então, se tudo é um CRUD, **a solução pode (e deve) ser simples**.
 
-O fluxo de dados funciona da seguinte forma: **CRUD → INTERFACE → CONTROLLERS → VIEWS/API**.
+O fluxo de dados funciona da seguinte forma: **CRUD → ENTIDADE → CONTROLLERS → VIEWS/API**.
 
 <ul>
   <li><p><b>CRUD: </b> Cada funcionalidade nasce como um CRUD básico. Pode crescer, mas sem virar um monstro. Nada de violar responsabilidade do arquivo.</p></li>
   <li><p><b>CLASSES: </b> São as classes que lidam diretamente com o BD. Isoladas, focadas. Um CRUD por classe. Se precisar, você estende.</p></li>
-  <li><p><b>CONTROLLERS: </b> Capturam os dados das interfaces, aplicam regras de negócio e preparam a saída.</p></li>
+  <li><p><b>CONTROLLERS: </b> Capturam os dados das entidades, aplicam regras de negócio e preparam a saída.</p></li>
   <li><p><b>VIEWS/API: </b> Aqui termina o ciclo. É só a apresentação: seja para humanos (HTML) ou máquinas (JSON, XML, etc). Nada de lógica aqui.</p></li>
 </ul>
 
@@ -41,9 +41,9 @@ PASTAS          | DESCRIÇÃO
 ----------------|------------
 /src            | Pasta contentendo serviços e entidades communs ao projeto, podem ser usados nos controllers, receiver, api, screens e etc.
 /src/services   | Pasta destinada a serviços como consumo de API de terceiros, serviços de email, serviços de pagamento como abstração de gatesways e etc.
-/src/entities   | Interfaces e modelos de CRUD (1 por funcionalidade)
+/src/entities   | Entidades de CRUD (1 por funcionalidade)
 /src/utils      | Classes utilitárias (tratamento de erros, queries, constantes)
-/controllers    | Regras de negócio e orquestração de dados (consome interface)
+/controllers    | Regras de negócio e orquestração de dados (consome entidade)
 /receiver       | Pasta para recebimento de hooks de outros sistemas ou API's
 /assets         | Arquivos de view (JS/CSS/HTML) em apps web e documentos estáticos como imagens, vídeos
 /api            | Endpoints públicos ou internos da aplicação (REST, JSON, etc).
@@ -59,21 +59,26 @@ PASTAS          | DESCRIÇÃO
 
 - As pastas abaixo são **obrigatórias** e formam o núcleo do backend na arquitetura **Zero**:
 
-  - ### 🔹 Interface (`/interface`)
-    - Cada funcionalidade do sistema (ex: Usuário, Produto, Pedido) tem **sua interface CRUD** separada.
-    - Essas interfaces definem os métodos esperados para qualquer tipo de operação com o banco.
+  - ### 🔹 Entities (`/src/entities`)
+    - Cada funcionalidade do sistema (ex: Usuário, Produto, Pedido) tem **sua entidade CRUD** separada.
+    - Essas entidades ou modelos definem os métodos esperados para qualquer tipo de operação com o banco.
     - São independentes da linguagem. Em TypeScript, Dart, Java... seguem o mesmo princípio.
-  
-  - ### 🔹 Controllers (`/controller`)
-    - Cada interface tem um controller correspondente.
-    - Ele **implementa** as chamadas para o banco via classe e alimenta **views ou APIs**.
-    - Exemplo: `UserController` chama `UserCRUD` e envia dados para o front ou resposta de API.
-  
-  - ### 🔹 Utils (`/utils`)
+
+  - ### 🔹 Utils (`/src/utils`)
     - Contém utilitários centrais que apoiam toda a camada de backend:
       - `ErrorHandler` → Classe abstrata que padroniza erros e mensagens de exceção.
       - `QueryProvider` → Armazena queries SQL como **constantes** ou **variáveis dinâmicas**, dependendo da linguagem.
       - `LogicHelper` → Funções para regra de negócio, máscaras, segurança, etc. (máx. ~10 funções).
+  
+  - ### 🔹 Services (`/src/services`)
+    - Contém serviços que consomem APIs de terceiros ou serviços externos:
+      - Exemplo: `PaymentGateway` para integração com gateways de pagamento.
+      - Cada serviço deve ser modular e reutilizável, podendo ser chamado por controllers ou outras partes do sistema.
+  
+  - ### 🔹 Controllers (`/controller`)
+    - Cada entidade tem um controller correspondente.
+    - Ele **implementa** as chamadas para o banco via classe e alimenta **views ou APIs**.
+    - Exemplo: `UserController` chama `UserCRUD` e envia dados para o front ou resposta de API.
 
 - As pastas abaixo são opcionais, devem ser incrementadas somente se necessário:
   
@@ -114,14 +119,14 @@ PASTAS          | DESCRIÇÃO
 
 ## 🚀 Escalabilidade
 
-Essa arquitetura suporta sistemas mais complexos, que contenham pedidos, estoque, comissão, notificações, suporte e etc, pois ela trata tudo como uma interface, por exemplo:
+Essa arquitetura suporta sistemas mais complexos, que contenham pedidos, estoque, comissão, notificações, suporte e etc, pois ela trata tudo como uma entidade, por exemplo:
 
 - Estoque é um CRUD;
 - Comissão é um CRUD;
 - Notificações é um CRUD;
 - Suporte é também um CRUD.
 
-Basicamente qualquer coisa é um CRUD, sendo que cada funcionalidade vai ter uma interface (CRUD), um controller com os métodos que asseguram o funcionamento correto do sistema, uma classe de rotas e seu próprio endpoint. Se for necessário atomicidade, então cabe o desenvolvedor escolher qual arquivo será responsável por controlar a atomicidade, por exemplo, imagine o seguinte fluxo: **CRIAR PEDIDOS → DISPARAR FATURAMENTO → ATUALIZAR O ESTOQUE → GERAR COMISSÃO PARA O VENDEDOR → ENVIAR UM EMAIL**.
+Basicamente qualquer coisa é um CRUD, sendo que cada funcionalidade vai ter uma entidade (CRUD), um controller com os métodos que asseguram o funcionamento correto do sistema, uma classe de rotas e seu próprio endpoint. Se for necessário atomicidade, então cabe o desenvolvedor escolher qual arquivo será responsável por controlar a atomicidade, por exemplo, imagine o seguinte fluxo: **CRIAR PEDIDOS → DISPARAR FATURAMENTO → ATUALIZAR O ESTOQUE → GERAR COMISSÃO PARA O VENDEDOR → ENVIAR UM EMAIL**.
 
 Se for necessário dar um rollback, é possível fazer de várias maneiras simples, sendo uma, que o sistema só valida tudo no final de todas as etapas, num arquivo que envia o email. Então o sistema cria o pedido e o insere no banco, que não teria problema se o pedido não fosse concluído já basta ter uma flag nesse pedido, sendo bom até para análises de marketing. Se ele conseguir atualizar o estoque, ele dispara o faturamento e se tudo ocorrer bem com o diparo, ele gera a comissão e envia o email.
 
@@ -203,12 +208,12 @@ interface PagamentosInterface {
 }
 
 class Pagamentos implements PagamentosInterface {
-    private BD $bancoDeDados;
+    private Bd $bancoDeDados;
 
     // Inicia a classe com uma conexão com o banco de dados.
     function __construct()
     {
-        $this->bancoDeDados = new BD;
+        $this->bancoDeDados = new Bd;
     }
 
     /**
@@ -272,7 +277,7 @@ class Pagamentos implements PagamentosInterface {
 
 ```php
 
-require_once '../classes/interface-pagamentos.php';
+require_once '../classes/Pagamentos.php';
 require_once '../utils/funcoes.php';
 
 /**

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ O fluxo de dados funciona da seguinte forma: **CRUD → CONTRACTS → WORKERS �
 
 PASTAS          | DESCRIÇÃO
 ----------------|------------
+/assets         | Arquivos de view (JS/CSS/HTML) em apps web e documentos estáticos como imagens, vídeos
 /contracts      | Contratos de CRUD (1 por funcionalidade)
 /utils          | Classes utilitárias (tratamento de erros, queries, constantes)
 /workers        | Regras de negócio e orquestração de dados (consome contrato)
 /receiver       | Pasta para recebimento de hooks de outros sistemas ou API's
-/assets         | Arquivos de view (JS/CSS/HTML) em apps web e documentos estáticos como imagens, vídeos
 /api            | Endpoints públicos ou internos da aplicação (REST, JSON, etc).
 /screens        | Para views em apps mobile ou desktop
 /utils          | Classes utilitárias (tratamento de erros, queries, constantes)


### PR DESCRIPTION
## Descrição
Trás algumas melhorias e sugestões nas convenções de nomes e organização de pastas. Uma das principais mudanças é alterar a pasta `interfaces` para `entidades` visto que uma entidade vai ter quase que 100% das vezes uma interface junto de uma classe no mesmo arquivo.

Além disso coloca adiciona o conceito de `services` e coloca parte da estrutura dentro de uma pasta `/src` por entendermos que `services`, `utils` e `entities` são partes comuns de todo o projeto, podendo ser usado em `receivers` e `api` e etc..